### PR TITLE
Style tags should be mapped to code blocks

### DIFF
--- a/src/html-to-ast.js
+++ b/src/html-to-ast.js
@@ -21,7 +21,7 @@ function removeUnusedProperties(node) {
 function mapNodeType(node, parent) {
     if (parent) {
         let parentNode = parent.parent.node;
-        if (parentNode.tagName === "script") {
+        if (parentNode.tagName === "script" || parentNode.tagName === "style") {
             return "CodeBlock";
         }
     }

--- a/test/HTMLProcessor-test.js
+++ b/test/HTMLProcessor-test.js
@@ -19,6 +19,13 @@ describe("HTMLProcessor-test", function () {
                 assert.equal(code.type, "CodeBlock");
             });
         });
+        it("style should CodeBlock", function () {
+            const result = parse(`<style> hr{border:0}body{margin:0} </style>`);
+            const script = result.children[0];
+            script.children.forEach(code => {
+                assert.equal(code.type, "CodeBlock");
+            });
+        });
         it("<p> should Paragraph", function () {
             const result = parse(`<p>test</p>`);
             const pTag = result.children[0];

--- a/test/ast-test-case/entities-in-literals/index.json
+++ b/test/ast-test-case/entities-in-literals/index.json
@@ -127,7 +127,7 @@
             "properties": {},
             "children": [
                 {
-                    "type": "Str",
+                    "type": "CodeBlock",
                     "value": "\nhtml > body {\n  color: red;\n}\n",
                     "loc": {
                         "start": {


### PR DESCRIPTION
I am using textlint to check HTML sentences.
CSS in the style tag was handled as sentences and a Lint error was output.
I thought that CSS in the style tag should be treated as a code block.
