### PR TITLE
Add support extensions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ What is textlint plugin? Please see https://github.com/textlint/textlint/blob/ma
 
     npm install textlint-plugin-html
 
-## Supported extensions
+## Default supported extensions
 
 - `.html`
 - `.htm`
@@ -30,6 +30,22 @@ Lint HTML file with textlint
 
 ```
 $ textlint index.html
+```
+
+### Options
+ - `extensions`: `string[]`
+    - Additional file extensions for html
+
+For example, if you want to treat `.custom-ext` as html, put following config to `.textlintrc`
+
+ ```json
+{
+    "plugins": {
+        "html": {
+            "extensions": [".custom-ext"]
+        }
+    }
+}
 ```
 
 ## Tests

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.1.1",
     "mocha": "^3.2.0",
     "power-assert": "^1.4.0",
-    "textlint": "^7.2.2",
+    "textlint": "^11.0.0",
     "textlint-ast-test": "^1.1.3",
     "textlint-rule-no-todo": "^2.0.0"
   },

--- a/src/HTMLProcessor.js
+++ b/src/HTMLProcessor.js
@@ -4,13 +4,14 @@ import {parse} from "./html-to-ast";
 export default class HTMLProcessor {
     constructor(config) {
         this.config = config;
+        this.extensions = this.config.extensions ? this.config.extensions : [];
     }
 
-    static availableExtensions() {
+    availableExtensions() {
         return [
             ".htm",
             ".html"
-        ];
+        ].concat(this.extensions);
     }
 
     processor(ext) {

--- a/test/HTMLProcessor-test.js
+++ b/test/HTMLProcessor-test.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 import assert from "power-assert";
-import HTMLProcessor from "../src/HTMLProcessor";
+import HTMLPlugin from "../src/index"
 import {parse} from "../src/html-to-ast";
 import {tagNameToType} from "../src/mapping";
 import {TextLintCore} from "textlint";
@@ -60,8 +60,8 @@ describe("HTMLProcessor-test", function () {
         context("when target file is a HTML", function () {
             beforeEach(function () {
                 textlint = new TextLintCore();
-                textlint.setupProcessors({
-                    HTMLProcessor: HTMLProcessor
+                textlint.setupPlugins({
+                    html: HTMLPlugin
                 });
                 textlint.setupRules({
                     "no-todo": require("textlint-rule-no-todo")
@@ -78,8 +78,8 @@ describe("HTMLProcessor-test", function () {
         context("support file extensions", function () {
             beforeEach(function () {
                 textlint = new TextLintCore();
-                textlint.setupProcessors({
-                    HTMLProcessor: HTMLProcessor
+                textlint.setupPlugins({
+                    html: HTMLPlugin
                 });
                 textlint.setupRules({
                     "no-todo": require("textlint-rule-no-todo")

--- a/test/HTMLProcessor-test.js
+++ b/test/HTMLProcessor-test.js
@@ -99,5 +99,29 @@ describe("HTMLProcessor-test", function () {
                 return Promise.all(promises);
             });
         });
+        context("when extensions option is specified", function () {
+            beforeEach(function () {
+                textlint = new TextLintCore();
+                textlint.setupPlugins(
+                    { html: HTMLPlugin },
+                    { html: {extensions: [".custom"]}}
+                );
+                textlint.setupRules({
+                    "no-todo": require("textlint-rule-no-todo")
+                });
+            });
+            it("should report error", function () {
+                const fixturePathList = [
+                    path.join(__dirname, "/fixtures/test.custom")
+                ];
+                const promises = fixturePathList.map((filePath) => {
+                    return textlint.lintFile(filePath).then(results => {
+                        assert(results.messages.length > 0);
+                        assert(results.filePath === filePath);
+                    });
+                });
+                return Promise.all(promises);
+            });
+        });
     });
 });

--- a/test/fixtures/test.custom
+++ b/test/fixtures/test.custom
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<div>
+    <p>
+        TODO: This is TODO
+    </p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
I want use this plugin for `.vue` files, but the plugin supports only `.html` or `.htm`.
And I added to support extensions option.
This will enable to support any template engine based on HTML.

This PR is inspired by https://github.com/textlint/textlint/pull/537 .